### PR TITLE
Fix the library after renaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-*.egg-info
+*.egg*
 build/
 *.pyc
 *.swp

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -14,4 +14,4 @@ Pull requests submitted through GitHub will be ignored.
 
 Bugs should be filed on Launchpad, not GitHub:
 
-   https://bugs.launchpad.net/os-capabilities
+   https://bugs.launchpad.net/os-traits

--- a/HACKING.rst
+++ b/HACKING.rst
@@ -1,4 +1,4 @@
-os-capabilities Style Commandments
+os-traits Style Commandments
 ===============================================
 
 Read the OpenStack Style Commandments http://docs.openstack.org/developer/hacking/

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -37,7 +37,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'os-capabilities'
+project = u'os-traits'
 copyright = u'2016, OpenStack Foundation'
 
 # If true, '()' will be appended to :func: etc. cross-reference text.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,9 +1,9 @@
-.. os-capabilities documentation master file, created by
+.. os-traits documentation master file, created by
    sphinx-quickstart on Tue Jul  9 22:26:36 2013.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to os-capabilities's documentation!
+Welcome to os-traits' documentation!
 ========================================================
 
 Contents:

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -4,9 +4,9 @@ Installation
 
 At the command line::
 
-    $ pip install os-capabilities
+    $ pip install os-traits
 
 Or, if you have virtualenvwrapper installed::
 
-    $ mkvirtualenv os-capabilities
-    $ pip install os-capabilities
+    $ mkvirtualenv os-traits
+    $ pip install os-traits

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -2,6 +2,6 @@
 Usage
 ========
 
-To use os-capabilities in a project::
+To use os-traits in a project::
 
-    import os_capabilities
+    import os_traits

--- a/os_traits/__init__.py
+++ b/os_traits/__init__.py
@@ -18,16 +18,16 @@ import pbr.version
 import six
 
 __version__ = pbr.version.VersionInfo(
-    'os_capabilities').version_string()
+    'os_traits').version_string()
 
 # Conveniently import all the constants into the main module "namespace"
-from os_capabilities.const import *
+from os_traits.const import *
 
 
 def get_symbol_names(prefix=None):
     """
-    Returns the names of symbols of capability strings in the
-    os_capabilities module, optionally filtered by a supplied prefix.
+    Returns the names of symbols of trait strings in the os_traits module,
+    optionally filtered by a supplied prefix.
 
     :param prefix: Optional string prefix to filter by. e.g. 'hw:'
     """
@@ -44,9 +44,9 @@ def get_symbol_names(prefix=None):
     ]
 
 
-def get_capabilities(prefix=None):
+def get_traits(prefix=None):
     """
-    Returns the capability strings in the os_capabilities module, optionally
+    Returns the trait strings in the os_traits module, optionally
     filtered by a supplied prefix.
 
     :param prefix: Optional string prefix to filter by. e.g. 'hw:'

--- a/os_traits/tests/test_os_traits.py
+++ b/os_traits/tests/test_os_traits.py
@@ -13,16 +13,16 @@
 # under the License.
 
 """
-test_os_capabilities
+test_os_traits
 ----------------------------------
 
-Tests for `os_capabilities` module.
+Tests for `os_traits` module.
 """
 
-from os_capabilities.tests import base
+from os_traits.tests import base
 
 
-class TestOs_capabilities(base.TestCase):
+class TestOs_traits(base.TestCase):
 
     def test_something(self):
         pass

--- a/releasenotes/source/conf.py
+++ b/releasenotes/source/conf.py
@@ -55,7 +55,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'os_capabilities Release Notes'
+project = u'os_traits Release Notes'
 copyright = u'2016, OpenStack Foundation'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/releasenotes/source/index.rst
+++ b/releasenotes/source/index.rst
@@ -1,5 +1,5 @@
 ============================================
- os_capabilities Release Notes
+ os_traits Release Notes
 ============================================
 
 .. toctree::


### PR DESCRIPTION
1. Rename the rest capabilities to traits
2. Correct .gitignore to exclude *.egg* generated by pbr
