### PR TITLE
Enable testing and add a new interface check_traits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ build/
 *.pyc
 *.swp
 .venv
+.testrepository
+.tox

--- a/.testr.conf
+++ b/.testr.conf
@@ -1,0 +1,8 @@
+[DEFAULT]
+test_command=OS_STDOUT_CAPTURE=${OS_STDOUT_CAPTURE:-1} \
+             OS_STDERR_CAPTURE=${OS_STDERR_CAPTURE:-1} \
+             OS_TEST_TIMEOUT=${OS_TEST_TIMEOUT:-60} \
+             ${PYTHON:-python} -m subunit.run discover -t ./ ${OS_TEST_PATH:-./os_traits/tests}  $LISTOPT $IDOPTION
+
+test_id_option=--load-list $IDFILE
+test_list_option=--list

--- a/os_traits/__init__.py
+++ b/os_traits/__init__.py
@@ -62,3 +62,18 @@ def get_traits(prefix=None):
         v not in excluded_values and
         (prefix is None or v.startswith(prefix))
     ]
+
+
+def check_traits(traits):
+    """
+    Returns a tuple of two trait string sets, the first set contains valid
+    traits, and the second contains others.
+
+    :param traits: An iterable contains trait strings.
+    """
+    trait_set = set(traits)
+    valid_trait_set = set(get_traits())
+
+    valid_traits = trait_set & valid_trait_set
+
+    return (valid_traits, trait_set - valid_traits)

--- a/os_traits/tests/test_os_traits.py
+++ b/os_traits/tests/test_os_traits.py
@@ -43,3 +43,13 @@ class TestOs_traits(base.TestCase):
         traits = ot.get_traits(ot.NAMESPACES['x86'])
         self.assertIn("hw:cpu:x86:sse42", traits)
         self.assertEqual(35, len(traits))
+
+    def test_check_traits(self):
+        traits = set(["hw:cpu:x86:sse42", "hw:cpu:x86:xop"])
+        not_traits = set(["not_trait1", "not_trait2"])
+
+        check_traits = []
+        check_traits.extend(traits)
+        check_traits.extend(not_traits)
+        self.assertEqual((traits, not_traits),
+                         ot.check_traits(check_traits))

--- a/os_traits/tests/test_os_traits.py
+++ b/os_traits/tests/test_os_traits.py
@@ -19,10 +19,27 @@ test_os_traits
 Tests for `os_traits` module.
 """
 
+import os_traits as ot
 from os_traits.tests import base
 
 
 class TestOs_traits(base.TestCase):
 
-    def test_something(self):
-        pass
+    def test_trait(self):
+        trait = ot.HW_CPU_X86_SSE42
+        self.assertEqual("hw:cpu:x86:sse42", trait)
+
+    def test_get_symbol_names(self):
+        names = ot.get_symbol_names()
+        self.assertIn("HW_CPU_X86_AVX2", names)
+        self.assertEqual(35, len(names))
+
+    def test_namespaces(self):
+        namespaces = ot.NAMESPACES
+        self.assertIn(("hardware", "hw:"), namespaces.items())
+        self.assertEqual(4, len(namespaces))
+
+    def test_get_traits(self):
+        traits = ot.get_traits(ot.NAMESPACES['x86'])
+        self.assertIn("hw:cpu:x86:sse42", traits)
+        self.assertEqual(35, len(traits))

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ install_command =
 setenv =
    VIRTUAL_ENV={envdir}
 deps = -r{toxinidir}/test-requirements.txt
-commands = python setup.py test --slowest --testr-args='{posargs}'
+commands = python setup.py testr --slowest --testr-args='{posargs}'
 
 [testenv:common-constraints]
 install_command = pip install -c{env:UPPER_CONSTRAINTS_FILE:https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt} {opts} {packages}


### PR DESCRIPTION
There're 3 commits:
- 1a89c57: Fix tox in py27 environment
- 87c5fa8: Add basic tests for os_traits
- f04ae23: Add a new interface "check_traits" with tests, please refer to [1] [2] [3] for its usage.

[1] https://review.openstack.org/#/c/377382/3/nova/api/openstack/placement/handlers/trait.py@87
[2] https://review.openstack.org/#/c/378601/3/nova/api/openstack/placement/handlers/trait.py@162
[3] https://review.openstack.org/#/c/377690/3/nova/api/openstack/placement/handlers/trait.py@101
